### PR TITLE
Allow chosing between TLS and STARTTLS

### DIFF
--- a/api/config.json.example
+++ b/api/config.json.example
@@ -7,7 +7,8 @@
     "from": "Sender Name <sender@example.com>",
     "smtp" : {
       "host": "mail.example.com",
-      "port": 587,
+      "port": 465,
+      "starttls": false,
       "username": "sender@example.com",
       "password": "!!!<<<CHANGEME>>>!!!"
     }

--- a/api/src/_helpers/send-email.js
+++ b/api/src/_helpers/send-email.js
@@ -10,7 +10,8 @@ async function sendEmail({ to, subject, html }) {
     const transporter = nodemailer.createTransport({
       host: config.mail.smtp.host,
       port: config.mail.smtp.port,
-      secure: true,
+      secure: !config.mail.smtp.starttls,
+      requiretls: config.mail.smtp.starttls,
       auth: {
         user: config.mail.smtp.username,
         pass: config.mail.smtp.password,

--- a/api/src/config.js
+++ b/api/src/config.js
@@ -16,7 +16,8 @@ const configSchema = Joi.object({
       from: Joi.string().required(),
       smtp: Joi.object({
         host: Joi.string().required(),
-        port: Joi.number().default(587),
+        port: Joi.number().default(465),
+        starttls: Joi.boolean().default(false),
         username: Joi.string().required(),
         password: Joi.string().required(),
       }).required(),


### PR DESCRIPTION
This allows to configure starttls: If ``starttls`` is configured, the mail server is contacted via regular smtp and a TLS session is initiated by sending STARTTLS. TLS is enforced in this case to prevent downgrade attacks, the connection is aborted if no TLS can be negotiated.

If ``starttls`` is set to ``false``, TLS without ``starttls`` is used instead (as is usually the case on port 465).

``secure`` setting from nodemailer is intentionally not exposed in configuration because exposing it without deducing it from requiretls would enable plaintext connections which seems undesireable.