### PR TITLE
Make sure htdocs is readable

### DIFF
--- a/frontend/Dockerfile-prod
+++ b/frontend/Dockerfile-prod
@@ -31,3 +31,4 @@ RUN sed -i '/<Directory "\/usr\/local\/apache2\/htdocs">/,/<\/Directory>/ s/Allo
 
 COPY --from=builder /opt/obs/frontend/build /usr/local/apache2/htdocs
 COPY apache/.htaccess /usr/local/apache2/htdocs/
+RUN chmod -R a+rX /usr/local/apache2/htdocs


### PR DESCRIPTION
This fixes a problem on servers where the umask is set such that the files downloaded via git do not get world-readable/listable permissions. Without this change, the permissions from the working directory propagate into the portal container and apache is not able to read the data on servers with umask 007.