### PR TITLE
Fix twist in filename

### DIFF
--- a/deployment/README.md
+++ b/deployment/README.md
@@ -53,7 +53,7 @@ Change the domain where it occurs, such as in `Host()` rules.
 ### Configure frontend
 
 ```bash
-cp source/frontend/config.json.example config/frontend.json
+cp source/frontend/config.example.json config/frontend.json
 vim frontend/src/config.json
 ```
 


### PR DESCRIPTION
the file is actually named `config.example.json`, fix the reference so the copy command works.