### PR TITLE
adapt endpoint to new scheme

### DIFF
--- a/frontend/config.example.json
+++ b/frontend/config.example.json
@@ -1,7 +1,7 @@
 {
-  "apiUrl": "https://api.example.com",
+  "apiUrl": "https://portal.example.com/api",
   "auth": {
-    "server": "https://api.example.com",
+    "server": "https://portal.example.com/api",
     "clientId": "CHANGEME",
     "scope": "*",
     "redirectUri": "https://example.com/redirect"


### PR DESCRIPTION
to be consistent with traefik endpoint and the new scheme we should use `/api` here, too.
@opatut mention as discussed