### PR TITLE
api.json for consistency.

### DIFF
--- a/deployment/examples/docker-compose.yaml
+++ b/deployment/examples/docker-compose.yaml
@@ -32,7 +32,7 @@ services:
       context: ./source/api
     volumes:
       - ./data/api-data:/data
-      - ./config/api-config.json:/opt/obs/api/config.json
+      - ./config/api.json:/opt/obs/api/config.json
     environment:
       - MONGODB_URL=mongo://mongo/obs
     restart: on-failure
@@ -56,7 +56,7 @@ services:
       context: ./source/api
     volumes:
       - ./data/api-data:/data
-      - ./config/api-config.json:/opt/obs/api/config.json
+      - ./config/api.json:/opt/obs/api/config.json
     links:
       - mongo
       - redis


### PR DESCRIPTION
`README.md` calls this `api.json` and further down we have a `frontend.json` so changing it here to be consistent with everything else.
@opatut @mention as discussed.