### PR TITLE
deployment/README.md: Clarifications

### DIFF
--- a/deployment/README.md
+++ b/deployment/README.md
@@ -112,10 +112,8 @@ docker-compose up -d
 
 ### Updates
 
-The current setup separates local configuration and data, simplifying git updates
-of the `sources`. However upgrades to newer versions may require more actions.
-A more extensive upgrade documentation is being worked on and will be added or
-linked here.
+Before updating make sure that you have properly backed-up your instance so you 
+can always roll back to a pre-update state.
 
 ### Backups
 

--- a/deployment/README.md
+++ b/deployment/README.md
@@ -19,16 +19,21 @@ frontend is reachable at the domain root.
 
 ### Clone the repo
 
-Create a folder somewhere in your system, we'll name it `$ROOT` from now on.
+First create a folder somewhere in your system, in the example we use 
+`/opt/openbikesensor` and export it as `$ROOT` to more easily refer to it.
 
-Clone the repository to `$ROOT/source`.  Ensure you also cloned the submodules,
-as described in the main [README](../README.md).
+Clone the repository to `$ROOT/source`.
 
 ```bash
-mkdir -p /opt/openbikesensor
-cd /opt/openbikesensor
-git clone https://github.com/openbikesensor/portal source/
+export ROOT=/opt/openbikesensor
+mkdir -p $ROOT
+cd $ROOT
+git clone --recursive https://github.com/openbikesensor/portal source/
+# ... or if you accidentally cloned non --recursive, to fix it run:
+# git submodule update --init --recursive
 ```
+
+Unles otherwise mentioned, commandlines below assume your `cwd` to be `$ROOT`
 
 ### Configure `traefik.toml`
 
@@ -59,6 +64,7 @@ vim frontend/src/config.json
 
 * Change all URLs to your domain
 * Create a UUID by using `uuidgen` and set the `clientId`
+* Change the coordinates of the map center to your liking
 
 ### Configure API
 
@@ -82,6 +88,7 @@ docker-compose up -d
 The services are being built the first time this is run. It can take some
 minutes.
 
+
 ## Miscellaneous
 
 ### Logs
@@ -98,3 +105,20 @@ If something went wrong, you can reconfigure your config files and rerun:
 docker-compose build
 docker-compose up -d
 ```
+
+#### Common issues
+- Errors about TLS issues on User cration point to something amiss in the mail server configuration.
+- Errors about unknown client point to ClientID mismatch between ``api.json`` and ``frontend.json``
+
+### Updates
+
+The current setup separates local configuration and data, simplifying git updates
+of the `sources`. However upgrades to newer versions may require more actions.
+A more extensive upgrade documentation is being worked on and will be added or
+linked here.
+
+### Backups
+
+To backup your instances private data you only need to backup the ``$ROOT`` folder.
+This should contain everything needed to start your instance again, no persistent
+data lives in docker containers.


### PR DESCRIPTION
- Formerly  `README.md` announced there would be $ROOT but it wasn't used - start using it
- Make sure that we also describe submodule cloning in Docker `README.md` as I have already been asked by several people "why the scripts directory isn't there".
- Mention how to adapt map center coordinates as it is a FAQ
- Mention how to backup the data.

@opatut mention as discussed