### PR TITLE
Ensure traefik can run on a bootstrapped env

### DIFF
--- a/deployment/examples/docker-compose.yaml
+++ b/deployment/examples/docker-compose.yaml
@@ -103,7 +103,7 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock
       - ./config/traefik.toml:/traefik.toml
       - ./config/usersfile:/usersfile
-      - ./data/acme.json:/acme.json
+      - ./config/acme:/acme
 
     networks:
       - gateway

--- a/deployment/examples/traefik.toml
+++ b/deployment/examples/traefik.toml
@@ -23,7 +23,8 @@
 # https://doc.traefik.io/traefik/v2.4/https/acme/#configuration-examples
 [certificatesResolvers.leresolver.acme]
   email = "info@example.com"
-  storage = "acme.json"
+  storage = "acme/acme.json"
+
   [certificatesResolvers.leresolver.acme.httpChallenge]
     # used during the challenge
     entryPoint = "web"


### PR DESCRIPTION
Traefik needs to be able to write a file. Previously compose would create a directory here in absence of a file. Use a directory volume instead so traefik can write the file if it ain't there but we can drop it there if we like.

@opatut single mention for this PR as discussed.