### PR TITLE
 needs to match  permitted redirect url in api

### DIFF
--- a/frontend/config.example.json
+++ b/frontend/config.example.json
@@ -4,7 +4,7 @@
     "server": "https://portal.example.com/api",
     "clientId": "CHANGEME",
     "scope": "*",
-    "redirectUri": "https://example.com/redirect"
+    "redirectUri": "https://portal.example.com/redirect"
   },
   "imprintUrl": "https://example.com/imprint",
   "privacyPolicyUrl": "https://example.com/privacy",


### PR DESCRIPTION
this needs to match the permitted URL in api config (`validRedirectUrls`)

I found this one trying to sed `portal.example.com` to my domain name

@opatut as discussed single @mention for this PR.