### PR TITLE
Show colorscale whenever it is used

### DIFF
--- a/frontend/src/components/ColorMapLegend.tsx
+++ b/frontend/src/components/ColorMapLegend.tsx
@@ -1,3 +1,5 @@
+import {useMemo} from "react";
+
 type ColorMap = [number, string][]
 
 import styles from './ColorMapLegend.module.less'
@@ -6,24 +8,20 @@ export default function ColorMapLegend({map}: {map: ColorMap}) {
   const min = map[0][0]
   const max = map[map.length - 1][0]
   const normalizeValue = (v) => (v - min) / (max - min)
-  if( typeof ColorMapLegend.counter == 'undefined' ) {
-     ColorMapLegend.counter = 0;
-  }
-  ColorMapLegend.counter++;
-  ColorMapLegend.id="gradient"+ColorMapLegend.counter;
-  ColorMapLegend.url="url(#"+ColorMapLegend.id+")";
+  const gradientId = useMemo(() => `gradient${Math.floor(Math.random() * 1000000)}`, []);
+  const gradientUrl = `url(#${gradientId})`;
   return (
     <div className={styles.colorMapLegend}>
       <svg width="100%" height="20" version="1.1" xmlns="http://www.w3.org/2000/svg">
         <defs>
-          <linearGradient id={ColorMapLegend.id} x1="0" x2="1" y1="0" y2="0">
+          <linearGradient id={gradientId} x1="0" x2="1" y1="0" y2="0">
             {map.map(([value, color]) => (
               <stop key={value} offset={normalizeValue(value) * 100 + '%'} stopColor={color} />
             ))}
           </linearGradient>
         </defs>
 
-        <rect id="rect1" x="0" y="0" width="100%" height="100%" fill={ColorMapLegend.url} />
+        <rect id="rect1" x="0" y="0" width="100%" height="100%" fill={gradientUrl} />
       </svg>
       {map.map(([value]) => (
         <span className={styles.tick} key={value} style={{left: normalizeValue(value) * 100 + '%'}}>

--- a/frontend/src/components/ColorMapLegend.tsx
+++ b/frontend/src/components/ColorMapLegend.tsx
@@ -6,19 +6,24 @@ export default function ColorMapLegend({map}: {map: ColorMap}) {
   const min = map[0][0]
   const max = map[map.length - 1][0]
   const normalizeValue = (v) => (v - min) / (max - min)
-
+  if( typeof ColorMapLegend.counter == 'undefined' ) {
+     ColorMapLegend.counter = 0;
+  }
+  ColorMapLegend.counter++;
+  ColorMapLegend.id="gradient"+ColorMapLegend.counter;
+  ColorMapLegend.url="url(#"+ColorMapLegend.id+")";
   return (
     <div className={styles.colorMapLegend}>
       <svg width="100%" height="20" version="1.1" xmlns="http://www.w3.org/2000/svg">
         <defs>
-          <linearGradient id="gradient" x1="0" x2="1" y1="0" y2="0">
+          <linearGradient id={ColorMapLegend.id} x1="0" x2="1" y1="0" y2="0">
             {map.map(([value, color]) => (
               <stop key={value} offset={normalizeValue(value) * 100 + '%'} stopColor={color} />
             ))}
           </linearGradient>
         </defs>
 
-        <rect id="rect1" x="0" y="0" width="100%" height="100%" fill="url(#gradient)" />
+        <rect id="rect1" x="0" y="0" width="100%" height="100%" fill={ColorMapLegend.url} />
       </svg>
       {map.map(([value]) => (
         <span className={styles.tick} key={value} style={{left: normalizeValue(value) * 100 + '%'}}>

--- a/frontend/src/mapstyles/index.js
+++ b/frontend/src/mapstyles/index.js
@@ -33,8 +33,9 @@ export function colormapToScale(colormap, value, min, max) {
 export const viridis = simplifyColormap(viridisBase.map(rgbArrayToColor), 20)
 export const grayscale = ['#FFFFFF', '#000000']
 export const reds = [
-  ['rgba', 255, 0, 0, 0],
-  ['rgba', 255, 0, 0, 1],
+  'rgba( 255, 0, 0, 0)',
+  'rgba( 255, 0, 0, 255)',
+]
 ]
 
 export function colorByCount(attribute = 'event_count', maxCount, colormap = viridis) {

--- a/frontend/src/mapstyles/index.js
+++ b/frontend/src/mapstyles/index.js
@@ -36,7 +36,6 @@ export const reds = [
   'rgba( 255, 0, 0, 0)',
   'rgba( 255, 0, 0, 255)',
 ]
-]
 
 export function colorByCount(attribute = 'event_count', maxCount, colormap = viridis) {
   return colormapToScale(colormap, ['case', ['to-boolean', ['get', attribute]], ['get', attribute], 0], 0, maxCount)

--- a/frontend/src/pages/MapPage/LayerSidebar.tsx
+++ b/frontend/src/pages/MapPage/LayerSidebar.tsx
@@ -8,7 +8,7 @@ import {
   setMapConfigFlag as setMapConfigFlagAction,
   initialState as defaultMapConfig,
 } from 'reducers/mapConfig'
-import {colorByDistance} from 'mapstyles'
+import {colorByDistance, colorByCount, reds} from 'mapstyles'
 import {ColorMapLegend} from 'components'
 
 const BASEMAP_STYLE_OPTIONS = [

--- a/frontend/src/pages/MapPage/LayerSidebar.tsx
+++ b/frontend/src/pages/MapPage/LayerSidebar.tsx
@@ -107,7 +107,7 @@ function LayerSidebar({
             <Header as="h4">Event points</Header>
           </label>
         </List.Item>
-        {showEvents && (
+        {(showEvents || showRoads) && (
           <>
             <List.Item>
               <ColorMapLegend map={_.chunk(colorByDistance('distance_overtaker')[3].slice(3), 2)} />

--- a/frontend/src/pages/MapPage/LayerSidebar.tsx
+++ b/frontend/src/pages/MapPage/LayerSidebar.tsx
@@ -93,6 +93,13 @@ function LayerSidebar({
             ) : null}
           </>
         )}
+        {showRoads && (
+          <>
+            <List.Item>
+              <ColorMapLegend map={_.chunk(colorByDistance('distance_overtaker')[3].slice(3), 2)} />
+            </List.Item>
+          </>
+        )}
         <Divider />
         <List.Item>
           <Checkbox
@@ -107,7 +114,7 @@ function LayerSidebar({
             <Header as="h4">Event points</Header>
           </label>
         </List.Item>
-        {(showEvents || showRoads) && (
+        {showEvents && (
           <>
             <List.Item>
               <ColorMapLegend map={_.chunk(colorByDistance('distance_overtaker')[3].slice(3), 2)} />

--- a/frontend/src/pages/MapPage/LayerSidebar.tsx
+++ b/frontend/src/pages/MapPage/LayerSidebar.tsx
@@ -81,6 +81,7 @@ function LayerSidebar({
               />
             </List.Item>
             {attribute.endsWith('_count') ? (
+             <>
               <List.Item>
                 <List.Header>Maximum value</List.Header>
                 <Input
@@ -90,14 +91,15 @@ function LayerSidebar({
                   onChange={(_e, {value}) => setMapConfigFlag('obsRoads.maxCount', value)}
                 />
               </List.Item>
-            ) : null}
-          </>
-        )}
-        {showRoads && (
-          <>
-            <List.Item>
-              <ColorMapLegend map={_.chunk(colorByDistance('distance_overtaker')[3].slice(3), 2)} />
-            </List.Item>
+              <List.Item>
+                <ColorMapLegend map={_.chunk(colorByCount('obsRoads.maxCount',mapConfig.obsRoads.maxCount, reds).slice(3), 2)} />
+              </List.Item></>
+            ) :
+            (
+              <List.Item>
+                <ColorMapLegend map={_.chunk(colorByDistance('distance_overtaker')[3].slice(3), 2)} />
+              </List.Item>
+            )}
           </>
         )}
         <Divider />


### PR DESCRIPTION
Previously the colorscale was hidden when no events were displayed. Now it is also shown when only roads are displayed.
![image](https://user-images.githubusercontent.com/44007906/146656817-5d2ed898-e769-4a56-984f-e3c61e22d847.png)
