### PR TITLE
mongo is not used any more.

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -7,15 +7,6 @@
 version: '3'
 
 services:
-  mongo:
-    image: mongo
-    tty: true
-    volumes:
-      - ./local/mongo:/data/db
-    ports:
-      - '27017:27017'
-    restart: on-failure
-
   postgres:
     image: "openmaptiles/postgis:6.0"
     environment:


### PR DESCRIPTION
We don't use mongodb any more so we can remove it from the dev docker-compose.yaml.