### PR TITLE
switch from link to depends_on

### DIFF
--- a/deployment/examples/docker-compose.yaml
+++ b/deployment/examples/docker-compose.yaml
@@ -26,8 +26,10 @@ services:
       - ./config/config.py:/opt/obs/api/config.py
       - ./data/tiles/:/tiles
     restart: on-failure
-    links:
+    depends_on:
       - postgres
+    # if you introduce a dockerized keycloak instance within this compose also:
+    # - keycloak
     labels:
       - traefik.http.routers.portal.rule=Host(`portal.example.com`)
       - traefik.http.routers.portal.entrypoints=websecure

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -32,7 +32,7 @@ services:
       - ./tile-generator:/opt/obs/tile-generator
       - ./local/api-data:/data
       - ./tile-generator/data/:/tiles
-    links:
+    depends_on:
       - postgres
       - keycloak
     ports:
@@ -52,7 +52,7 @@ services:
       - ./api/tools:/opt/obs/api/tools
       - ./api/config.dev.py:/opt/obs/api/config.py
       - ./local/api-data:/data
-    links:
+    depends_on:
       - postgres
       - keycloak
     restart: on-failure
@@ -70,7 +70,7 @@ services:
       - ./frontend/tsconfig.json:/opt/obs/frontend/tsconfig.json
       - ./frontend/package.json:/opt/obs/frontend/package.json
       - ./frontend/webpack.config.js:/opt/obs/frontend/webpack.config.js
-    links:
+    depends_on:
       - api
     environment:
       # used for proxy only
@@ -86,7 +86,7 @@ services:
     image: jboss/keycloak
     ports:
       - 3003:8080
-    links:
+    depends_on:
       - postgres
     environment:
       KEYCLOAK_USER: admin


### PR DESCRIPTION
@boldt mentioned this would allow to express dependencies - Tested it on dev portal and it works. With ``links`` the containers start out-of-order and starting a single container does not start its dependencies. With ``depends_on`` containers start in the correct temporal order and dependencies get started before the start of a named compose container.

A follow-up PR will add a retry to the keycloak connection to avoid a hanging api container on missing keycloak.