### PR TITLE
Api to retry keycloak on connection errors at startup

### DIFF
--- a/api/obs/api/routes/login.py
+++ b/api/obs/api/routes/login.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 import os
 
@@ -23,6 +24,14 @@ client = Client(client_authn_method=CLIENT_AUTHN_METHOD)
 async def connect_auth_client(app, loop):
     client.allow["issuer_mismatch"] = True
     client.provider_config(app.config.KEYCLOAK_URL)
+    try:
+        client.provider_config(app.config.KEYCLOAK_URL)
+    except:
+        log.exception(f"could not connect to {app.config.KEYCLOAK_URL}")
+        log.info("will retry")
+        await asyncio.sleep(2)
+        log.info("retrying")
+        await connect_auth_client(app,loop)
     client.store_registration_info(
         RegistrationResponse(
             client_id=app.config.KEYCLOAK_CLIENT_ID,


### PR DESCRIPTION
Prior to this PR API would get stuck when unsuccessfully connecting to keycloak and did neither retry nor exit the process properly. This happened at least in "development" mode due to (guessing here) sanics auto-reload facility on python file change, but even there a stuck container is a nuisance.

When connection times out or is rejected it raises ``RequestExceptions``. With this PR we retry with a short wait to avoid denial-of-servicing keycloak. This should make api/portal independent of keycloak startup time.

We might need to do something similar for postgres connection, but I didn't observe problems there yet.