### PR TITLE
Adapt dev config to match deployment compose example

### DIFF
--- a/api/config.py.example
+++ b/api/config.py.example
@@ -47,7 +47,7 @@ TILES_FILE = None
 
 # Path overrides:
 # API_ROOT_DIR = "??" # default: api/ inside repository
-# DATA_DIR = "??" # default: $API_ROOT_DIR/..
+DATA_DIR = "/data" # default if unset: $API_ROOT_DIR/../data
 # PROCESSING_DIR = "??" # default: DATA_DIR/processing
 # PROCESSING_OUTPUT_DIR = "??"  # default: DATA_DIR/processing-output
 # TRACKS_DIR = "??" # default: DATA_DIR/tracks


### PR DESCRIPTION
We use ``DATA_DIR="/data"`` everywhere, in the dev examples as well as in the deployment ``docker-compose.yaml``. So we should also use ``/data`` here in ``config.example.py``. We could also switch the relative default directory, but IMHO it is better to have it explicit in the config, that way nobody will be surprised by writes to ``/data``.

Currently the deployment ``docker-compose`` if deployed as instructed fails to upload tracks because of the inconsistency.

I discussed with @boldt about this - we came to the conclusion that alternatively we could also either:
- change the other files to also use ``/opt/obs/data``
- change ``app.py`` to default to ``/data``

But this proposed change is least invasive and therefore I'm proposing it - I'm willing to implement the alternatives if there were reasons for doing so we overlooked.
