### PR TITLE
[WIP] Simplified deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -91,7 +91,8 @@ ADD api/obs /opt/obs/api/obs/
 ADD api/tools /opt/obs/api/tools/
 RUN pip install -e /opt/obs/api/
 
-ADD roads_import.lua /opt/obs/api/roads_import.lua
+ADD roads_import.lua /opt/obs/api/tools
+ADD osm2pgsql.sh /opt/obs/api/tools
 
 COPY --from=frontend-builder /opt/obs/frontend/build /opt/obs/frontend/build
 COPY --from=osm2pgsql-builder /usr/local/bin/osm2pgsql /usr/local/bin/osm2pgsql

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,45 @@
 # This dockerfile is for the API + Frontend production image
 
 #############################################
+# Build osm2pgsql AS builder
+#############################################
+
+# This image should be the same as final one, because of the lib versions
+FROM python:3.9.7-bullseye as osm2pgsql-builder
+
+ARG DEBIAN_FRONTEND=noninteractive
+ENV TZ=Europe/Berlin
+ENV OSM2PGSQL_VERSION=1.5.1
+
+# Dependencies
+RUN apt-get update &&\
+    apt-get install -y \
+    make \
+    cmake \
+    g++ \
+    libboost-dev \
+    libboost-system-dev \
+    libboost-filesystem-dev \
+    libexpat1-dev \
+    zlib1g-dev \
+    libbz2-dev \
+    libpq-dev \
+    libproj-dev \
+    lua5.3 \
+    liblua5.3-dev \
+    git &&\
+    rm -rf /var/lib/apt/lists/*
+
+# Clone & Build
+RUN git clone  --branch $OSM2PGSQL_VERSION git://github.com/openstreetmap/osm2pgsql.git &&\
+    cd osm2pgsql/ &&\
+    mkdir build &&\
+    cd build &&\
+    cmake .. &&\
+    make &&\
+    make install
+
+#############################################
 # Build the frontend AS builder
 #############################################
 
@@ -23,6 +62,20 @@ RUN npm run build
 
 FROM python:3.9.7-bullseye
 
+RUN apt-get update &&\
+    apt-get install -y \
+    libboost-dev \
+    libboost-system-dev \
+    libboost-filesystem-dev \
+    libexpat1-dev \
+    zlib1g-dev \
+    libbz2-dev \
+    libpq-dev \
+    libproj-dev \
+    lua5.3 \
+    liblua5.3-dev &&\
+    rm -rf /var/lib/apt/lists/*
+
 WORKDIR /opt/obs/api
 
 ADD api/requirements.txt  /opt/obs/api/
@@ -38,9 +91,11 @@ ADD api/obs /opt/obs/api/obs/
 ADD api/tools /opt/obs/api/tools/
 RUN pip install -e /opt/obs/api/
 
+ADD roads_import.lua /opt/obs/api/roads_import.lua
+
 COPY --from=frontend-builder /opt/obs/frontend/build /opt/obs/frontend/build
+COPY --from=osm2pgsql-builder /usr/local/bin/osm2pgsql /usr/local/bin/osm2pgsql
 
 EXPOSE 8000
 
 CMD ["openbikesensor-api"]
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -97,6 +97,6 @@ ADD osm2pgsql.sh /opt/obs/api/tools
 COPY --from=frontend-builder /opt/obs/frontend/build /opt/obs/frontend/build
 COPY --from=osm2pgsql-builder /usr/local/bin/osm2pgsql /usr/local/bin/osm2pgsql
 
-EXPOSE 8000
+EXPOSE 3000
 
 CMD ["openbikesensor-api"]

--- a/api/obs/api/app.py
+++ b/api/obs/api/app.py
@@ -1,9 +1,10 @@
 import logging
 import re
+
 from json import JSONEncoder, dumps
 from functools import wraps, partial
 from urllib.parse import urlparse
-from os.path import dirname, join, normpath, abspath
+from os.path import dirname, join, normpath, abspath, isfile
 from datetime import datetime, date
 
 from sanic import Sanic, Blueprint
@@ -26,7 +27,7 @@ log = logging.getLogger(__name__)
 
 app = Sanic("OpenBikeSensor Portal API", load_env="OBS_", log_config={})
 
-if os.path.isfile("./config.py"):
+if isfile("./config.py"):
     app.update_config("./config.py")
 
 c = app.config

--- a/api/obs/api/app.py
+++ b/api/obs/api/app.py
@@ -24,8 +24,11 @@ from obs.api.db import User, make_session, connect_db
 
 log = logging.getLogger(__name__)
 
-app = Sanic("OpenBikeSensor Portal API", log_config={})
-app.update_config("./config.py")
+app = Sanic("OpenBikeSensor Portal API", load_env="OBS_", log_config={})
+
+if os.path.isfile("./config.py"):
+    app.update_config("./config.py")
+
 c = app.config
 
 api = Blueprint("api", url_prefix="/api")
@@ -104,7 +107,11 @@ Session(app, interface=InMemorySessionInterface())
 
 @app.before_server_start
 async def app_connect_db(app, loop):
-    app.ctx._db_engine_ctx = connect_db(app.config.POSTGRES_URL, app.config.POSTGRES_POOL_SIZE, app.config.POSTGRES_MAX_OVERFLOW)
+    app.ctx._db_engine_ctx = connect_db(
+        app.config.POSTGRES_URL,
+        app.config.POSTGRES_POOL_SIZE,
+        app.config.POSTGRES_MAX_OVERFLOW,
+    )
     app.ctx._db_engine = await app.ctx._db_engine_ctx.__aenter__()
 
 

--- a/deployment/README.md
+++ b/deployment/README.md
@@ -78,22 +78,30 @@ sure to configure:
 
 ### Prepare database
 
-Follow the procedure outlined in [README.md](../README.md) under "Prepare
-database". Whenever the docker-compose service `api` is referenced, replace it
-with `portal`, which contains the same python code as the development `api`
-service, but also the frontend. For example:
+Run the following two scripts to prepare the database:
 
 ```bash
-# development
-docker-compose run --rm api tools/prepare_sql_tiles.py
-# production
+docker-compose run --rm portal tools/reset_database.py
 docker-compose run --rm portal tools/prepare_sql_tiles.py
 ```
 
+For more details, see [README.md](../README.md) under "Prepare database".
+
 ### Import OpenStreetMap data
 
-Follow the procedure outlined in [README.md](../README.md) under "Import OpenStreetMap data".
+First of all, download the area(s) you would like to import from [GeoFabrik](https://download.geofabrik.de) into `data/pbf`, for example:
 
+```bash
+wget https://download.geofabrik.de/europe/germany/schleswig-holstein-latest.osm.pbf -P data/pbf
+```
+
+Afterwards,run the following script:
+
+```
+docker-compose run --rm portal tools/osm2pgsql.sh
+```
+
+For more details. see [README.md](../README.md) under "Import OpenStreetMap data".
 
 ### Configure portal
 

--- a/deployment/examples/.env
+++ b/deployment/examples/.env
@@ -1,0 +1,47 @@
+###################################################
+# Keycloak
+###################################################
+
+OBS_KEYCLOAK_URI=portal.example.com
+
+# Postgres
+
+OBS_KEYCLOAK_POSTGRES_USER=obs
+OBS_KEYCLOAK_POSTGRES_PASSWORD=<<TODO>>
+OBS_KEYCLOAK_POSTGRES_DB=obs
+
+# KeyCloak
+
+OBS_KEYCLOAK_POSTGRES_HOST=postgres-keycloak
+OBS_KEYCLOAK_ADMIN_USER=admin
+OBS_KEYCLOAK_ADMIN_PASSWORD=<<TODO>>
+OBS_KEYCLOAK_REALM=obs
+OBS_KEYCLOAK_PORTAL_REDIRECT_URI=https://obs.example.com/*
+
+###################################################
+# Portal
+###################################################
+
+OBS_PORTAL_URI=portal.example.com
+
+# Postgres + osm2pgsql
+
+OBS_POSTGRES_HOST=postgres
+OBS_POSTGRES_USER=obs
+OBS_POSTGRES_PASSWORD=<<TODO>>
+OBS_POSTGRES_DB=obs
+
+# Portal
+
+OBS_HOST=0.0.0.0
+OBS_PORT=3000
+OBS_SECRET=<<TODO>>
+OBS_POSTGRES_URL=postgresql+asyncpg://obs:<<TODO>>@postgres/obs
+OBS_KEYCLOAK_URL=https://login.example.com/auth/realms/obs/
+OBS_KEYCLOAK_CLIENT_ID=portal
+OBS_KEYCLOAK_CLIENT_SECRET=<<TODO>>
+OBS_DEDICATED_WORKER="True"
+OBS_DATA_DIR=/data
+OBS_PROXIES_COUNT=1
+
+###################################################

--- a/deployment/examples/.env
+++ b/deployment/examples/.env
@@ -16,7 +16,7 @@ OBS_KEYCLOAK_POSTGRES_HOST=postgres-keycloak
 OBS_KEYCLOAK_ADMIN_USER=admin
 OBS_KEYCLOAK_ADMIN_PASSWORD=<<TODO>>
 OBS_KEYCLOAK_REALM=obs
-OBS_KEYCLOAK_PORTAL_REDIRECT_URI=https://obs.example.com/*
+OBS_KEYCLOAK_PORTAL_REDIRECT_URI=https://portal.example.com/*
 
 ###################################################
 # Portal

--- a/deployment/examples/config.py
+++ b/deployment/examples/config.py
@@ -1,0 +1,60 @@
+# Bind address of the server
+#HOST = "127.0.0.1"
+#PORT = 3000
+
+# Extended log output, but slower
+DEBUG = False
+AUTO_RESTART = DEBUG
+
+# Required to encrypt or sign sessions, cookies, tokens, etc.
+#SECRET = "!!!<<<CHANGEME>>>!!!"
+
+# Connection to the database
+#POSTGRES_URL = "postgresql+asyncpg://user:pass@host/dbname"
+
+# URL to the keycloak realm, as reachable by the API service. This is not
+# necessarily its publicly reachable URL, keycloak advertises that iself.
+#KEYCLOAK_URL = "http://localhost:1234/auth/realms/obs/"
+
+# Auth client credentials
+#KEYCLOAK_CLIENT_ID = "portal"
+#KEYCLOAK_CLIENT_SECRET = "00000000-0000-0000-0000-000000000000"
+
+# Whether the API should run the worker loop, or a dedicated worker is used
+#DEDICATED_WORKER = True
+
+# The root of the frontend. Needed for redirecting after login, and for CORS.
+# Set to None if frontend is served by the API.
+FRONTEND_URL = None
+FRONTEND_HTTPS = True
+
+# Where to find the compiled frontend assets (must include index.html), or None
+# to disable serving the frontend.
+FRONTEND_DIR = "../frontend/build/"
+
+# Can be an object or a JSON string
+FRONTEND_CONFIG = {
+    "imprintUrl": "https://example.com/imprint",
+    "privacyPolicyUrl": "https://example.com/privacy",
+    "mapHome": {"zoom": 6, "longitude": 10.2, "latitude": 51.3},
+    "banner": {"text": "This is a test installation.", "style": "warning"},
+}
+
+# If the API should serve generated tiles, this is the path where the tiles are
+# built. This is an experimental option and probably very inefficient, a proper
+# tileserver should be prefered. Set to None to disable.
+TILES_FILE = None
+
+# Path overrides:
+# API_ROOT_DIR = "??" # default: api/ inside repository
+# DATA_DIR = "??" # default: $API_ROOT_DIR/..
+# PROCESSING_DIR = "??" # default: DATA_DIR/processing
+# PROCESSING_OUTPUT_DIR = "??"  # default: DATA_DIR/processing-output
+# TRACKS_DIR = "??" # default: DATA_DIR/tracks
+# OBS_FACE_CACHE_DIR = "??" # default: DATA_DIR/obs-face-cache
+
+# Additional allowed origins for CORS headers. The FRONTEND_URL is included by
+# default. Python list, or whitespace separated string.
+ADDITIONAL_CORS_ORIGINS = None
+
+# vim: set ft=python :

--- a/deployment/examples/docker-compose.yaml
+++ b/deployment/examples/docker-compose.yaml
@@ -23,10 +23,16 @@ services:
     image: openbikesensor-portal
     build:
       context: ./source
+    environment:
+      POSTGRES_HOST: postgres
+      POSTGRES_USER: obs
+      POSTGRES_PASSWORD: obs
+      POSTGRES_DB: obs
     volumes:
       - ./data/api-data:/data
       - ./config/config.py:/opt/obs/api/config.py
       - ./data/tiles/:/tiles
+      - ./data/pbf/:/pbf
     restart: on-failure
     depends_on:
       - postgres

--- a/deployment/examples/docker-compose.yaml
+++ b/deployment/examples/docker-compose.yaml
@@ -8,12 +8,17 @@ networks:
     internal: true
 
 services:
+
+  ############################################################
+  # Portal
+  ############################################################
+
   postgres:
     image: "openmaptiles/postgis:6.0"
     environment:
-      POSTGRES_USER: obs
-      POSTGRES_PASSWORD: obs
-      POSTGRES_DB: obs
+      - POSTGRES_DB=${OBS_POSTGRES_DB}
+      - POSTGRES_USER=${OBS_POSTGRES_USER}
+      - POSTGRES_PASSWORD=${OBS_POSTGRES_PASSWORD}
     volumes:
     - ./data/postgres/data:/var/lib/postgresql/data
     networks:
@@ -23,31 +28,49 @@ services:
     image: openbikesensor-portal
     build:
       context: ./source
-    environment:
-      POSTGRES_HOST: postgres
-      POSTGRES_USER: obs
-      POSTGRES_PASSWORD: obs
-      POSTGRES_DB: obs
+    env_file: .env
     volumes:
-      - ./data/api-data:/data
+      - ./data/api-data:${OBS_DATA_DIR}
       - ./config/config.py:/opt/obs/api/config.py
       - ./data/tiles/:/tiles
       - ./data/pbf/:/pbf
     restart: on-failure
     depends_on:
+      - traefik
       - postgres
-    # if you introduce a dockerized keycloak instance within this compose also:
+      - worker
     # - keycloak
     labels:
-      - traefik.http.routers.portal.rule=Host(`portal.example.com`)
+      - traefik.http.routers.portal.rule=Host(`${OBS_PORTAL_URI}`)
       - traefik.http.routers.portal.entrypoints=websecure
       - traefik.http.routers.portal.tls=true
       - traefik.http.routers.portal.tls.certresolver=leresolver
       - traefik.docker.network=gateway
-      - traefik.http.services.whoami.loadbalancer.server.port=80
+#      - traefik.http.services.portal.loadbalancer.server.port=3000
     networks:
       - gateway
       - backend
+
+  worker:
+    image: openbikesensor-portal
+    build:
+      context: ./source
+    env_file: .env
+    volumes:
+      - ./data/api-data:${OBS_DATA_DIR}
+      - ./config/config.py:/opt/obs/api/config.py
+    restart: on-failure
+    depends_on:
+      - postgres
+    networks:
+      - backend
+    command:
+      - python
+      - tools/process_track.py
+
+  ############################################################
+  # Traefik
+  ############################################################
 
   traefik:
     image: traefik:2.4.8
@@ -76,11 +99,52 @@ services:
       # Configure middlewares
       - "traefik.http.middlewares.redirect-http-to-https.redirectscheme.scheme=https"
 
-      # Show Traefik Dashboard. Enable the dashboard in traefik.toml if you use these.
-      # - "traefik.http.routers.traefik.rule=Host(`traefik.example.com`)"
-      # - "traefik.http.routers.traefik.service=api@internal"
-      # - "traefik.http.routers.traefik.tls=true"
-      # - "traefik.http.routers.traefik.entrypoints=websecure"
-      # - "traefik.http.routers.traefik.tls.certresolver=leresolver"
-      # - "traefik.http.routers.traefik.middlewares=basic-auth"
-      # - "traefik.http.middlewares.basic-auth.basicauth.usersfile=/usersfile"
+  ############################################################
+  # Keycloak
+  ############################################################
+
+  keycloak:
+    image: jboss/keycloak:15.1.0
+    restart: always
+    networks:
+      - gateway
+      - backend
+    env_file: .env
+    environment:
+      # database
+      - DB_VENDOR=postgres
+      - DB_ADDR=${OBS_KEYCLOAK_POSTGRES_HOST}
+      - DB_DATABASE=${OBS_KEYCLOAK_POSTGRES_DB}
+      - DB_USER=${OBS_KEYCLOAK_POSTGRES_USER}
+      - DB_PASSWORD=${OBS_KEYCLOAK_POSTGRES_PASSWORD}
+      # admin user
+      - KEYCLOAK_USER=${OBS_KEYCLOAK_ADMIN_USER}
+      - KEYCLOAK_PASSWORD=${OBS_KEYCLOAK_ADMIN_PASSWORD}
+      - PROXY_ADDRESS_FORWARDING=true
+      - OBS_KEYCLOAK_PORTAL_REDIRECT_URI=${OBS_KEYCLOAK_PORTAL_REDIRECT_URI}
+    depends_on:
+      - traefik
+      - postgres-keycloak
+    labels:
+      - "traefik.http.routers.login.rule=Host(`${OBS_KEYCLOAK_URI}`)"
+      - "traefik.http.routers.login.entrypoints=websecure"
+      - "traefik.http.routers.login.tls=true"
+      - "traefik.http.routers.login.tls.certresolver=leresolver"
+      # This container runs on two ports (8080/tcp, 8443/tcp). Tell traefik, which one to use.
+      - "traefik.http.services.login.loadbalancer.server.port=8080"
+      # This container runs on more than one network. Tell traefik, which one to use.
+      - "traefik.docker.network=gateway"
+
+  postgres-keycloak:
+    image: postgres:13.3
+    restart: always
+    networks:
+      - backend
+    volumes:
+    - ./data/postgres-keycloak:/var/lib/postgresql/data
+    environment:
+      - POSTGRES_DB=${OBS_KEYCLOAK_POSTGRES_DB}
+      - POSTGRES_USER=${OBS_KEYCLOAK_POSTGRES_USER}
+      - POSTGRES_PASSWORD=${OBS_KEYCLOAK_POSTGRES_PASSWORD}
+    labels:
+      - traefik.enable=false

--- a/deployment/examples/docker-compose.yaml
+++ b/deployment/examples/docker-compose.yaml
@@ -1,4 +1,4 @@
-version: '3'
+version: '3.5'
 
 networks:
   gateway:
@@ -16,6 +16,8 @@ services:
       POSTGRES_DB: obs
     volumes:
     - ./data/postgres/data:/var/lib/postgresql/data
+    networks:
+      - backend
 
   portal:
     image: openbikesensor-portal

--- a/osm2pgsql.sh
+++ b/osm2pgsql.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-osm2pgsql --create --hstore --style tools/roads_import.lua -O flex -d postgresql://$POSTGRES_USER:$POSTGRES_PASSWORD@$POSTGRES_HOST/$POSTGRES_DB /pbf/*.osm.pbf
+osm2pgsql --create --hstore --style tools/roads_import.lua -O flex -d postgresql://$OBS_POSTGRES_USER:$OBS_POSTGRES_PASSWORD@$OBS_POSTGRES_HOST/$OBS_POSTGRES_DB /pbf/*.osm.pbf
 

--- a/osm2pgsql.sh
+++ b/osm2pgsql.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo $POSTGRES_PASSWORD | osm2pgsql --create --hstore --style tools/roads_import.lua -O flex -H $POSTGRES_HOST -d $POSTGRES_DB -U $POSTGRES_USER -W /pbf/*.osm.pbf

--- a/osm2pgsql.sh
+++ b/osm2pgsql.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
 
-echo $POSTGRES_PASSWORD | osm2pgsql --create --hstore --style tools/roads_import.lua -O flex -H $POSTGRES_HOST -d $POSTGRES_DB -U $POSTGRES_USER -W /pbf/*.osm.pbf
+osm2pgsql --create --hstore --style tools/roads_import.lua -O flex -d postgresql://$POSTGRES_USER:$POSTGRES_PASSWORD@$POSTGRES_HOST/$POSTGRES_DB /pbf/*.osm.pbf
+


### PR DESCRIPTION
This MR adds:
* `osm2pgsql` to the portal container  to simplify the import of the osm data.
    * Added osm2pgsql to the portal container
    * Fix EXPOSE port to 3000
    * Add postgres to the backend network
    * Added POSTGRES env-vars to the portal (only handled by `osm2pgsql.sh` until now)
    * Added `./data/pbf:/pbf` as host volume mount to the portal
    * Added `osm2pgsql.sh, which ueses the env-vars and pbf-mount to import the osm data into the database
    * Allow env-vars starting with OBS_ to configure the portal
* Use environment variables to configure the portal 
    * Added an example .env file, where all variables start with `OBS_`
    * `OBS_` variables are handled by the portal as configuration variables
    * Uncomment some variables in the config.py, since the config.py overrides the env-vars
    * Use env-vars and env-file in the docker-compose.yaml
    * Add the worker to the docker-compose.yaml
    * Add KeyCloak with its own postgres to the docker-compose.yaml