### PR TITLE
bump those versions that we can bump

### DIFF
--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -1,13 +1,13 @@
-sanic~=21.9.1
+sanic~=21.9.3
 oic~=1.3.0
 sanic-session~=0.8.0
 sanicargs~=2.1.0
-sanic-cors~=1.0.1
+sanic-cors~=2.0.1
 python-slugify~=5.0.2
 motor~=2.5.1
 pyyaml<6
 -e git+https://github.com/openmaptiles/openmaptiles-tools#egg=openmaptiles-tools
 sqlparse~=0.4.2
-sqlalchemy[asyncio]~=1.4.25
+sqlalchemy[asyncio]~=1.4.31
 asyncpg~=0.24.0
-pyshp~=2.1.3
+pyshp~=2.2.0

--- a/api/setup.py
+++ b/api/setup.py
@@ -10,16 +10,16 @@ setup(
     packages=find_packages(),
     package_data={},
     install_requires=[
-        "sanic~=21.9.1",
+        "sanic~=21.9.3",
         "oic>=1.3.0, <2",
         "sanic-session~=0.8.0",
         "sanicargs~=2.1.0",
-        "sanic-cors~=1.0.1",
+        "sanic-cors~=2.0.1",
         "python-slugify~=5.0.2",
         "motor~=2.5.1",
         "sqlparse~=0.4.2",
         "openmaptiles-tools",  # install from git
-        "pyshp~=2.1.3",
+        "pyshp~=2.2.0",
     ],
     entry_points={
         "console_scripts": [


### PR DESCRIPTION
These were dependabot dependencies that I managed to integrate without issues - portal was still running and displaying tracks after.