### PR TITLE
Fix keycloak URI in example config

### DIFF
--- a/deployment/examples/.env
+++ b/deployment/examples/.env
@@ -2,7 +2,7 @@
 # Keycloak
 ###################################################
 
-OBS_KEYCLOAK_URI=portal.example.com
+OBS_KEYCLOAK_URI=login.example.com
 
 # Postgres
 


### PR DESCRIPTION
Just a minor fix in the example config: In the example login.example.com is used for the subdomain for the keycloak instance, so this should be the value in the example .env file.