### PR TITLE
reorder steps, add remark about rebuilding image 

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -7,11 +7,16 @@ development) and [deployment/README.md](deployment/README.md) (for production).
 
 ## 0.5.0
 
-* **Prepare SQL Tiles**: required
-* **OSM Import**: no
-* **Migration**: required
-* **Reimport tracks**: required
-* **Config changes**: none
+The upgrade requires the following steps in the given order
+
+- Rebuild images
+- Stop your portal and worker services.
+- **Migration with alembic**: required 
+- **Prepare SQL Tiles**: required 
+- Start your portal and worker services.
+- **Reimport tracks**: required 
+- **OSM Import**: no action required
+- **Config changes**: none
 
 ## 0.4.1
 


### PR DESCRIPTION
(as image rebuild was explicit in 0.4.0) as well as mentioning to stop the running services before upgrading DB schema.