### PR TITLE
Remove transformation in mapdetails_road of Road.geometry

### DIFF
--- a/api/obs/api/routes/mapdetails.py
+++ b/api/obs/api/routes/mapdetails.py
@@ -35,7 +35,7 @@ async def mapdetails_road(req):
     if not (1 <= radius <= 1000):
         raise InvalidUsage("`radius` parameter must be between 1 and 1000")
 
-    road_geometry = func.ST_Transform(Road.geometry, 3857)
+    road_geometry = Road.geometry
     point = func.ST_Transform(
         func.ST_GeomFromGeoJSON(
             json.dumps(


### PR DESCRIPTION
The transformation of Road.geometry prevents the use of the database column index. The data in the column geometry is already SRID 3857. Without this transformation lookups of road details in the map are much faster.