### PR TITLE
Fix #206 - Overtaking events are deleted now, when the parent track is deleted

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ to import the whole region you are serving.
 
     ```bash
     osm2pgsql --create --hstore --style roads_import.lua -O flex \
-      -H localhost -d obs -U obs \
+      -H localhost -d obs -U obs -W \
       path/to/downloaded/myarea-latest.osm.pbf 
     ```
 

--- a/api/obs/api/db.py
+++ b/api/obs/api/db.py
@@ -403,22 +403,22 @@ class Comment(Base):
 
 Comment.author = relationship("User", back_populates="authored_comments")
 User.authored_comments = relationship(
-    "Comment", order_by=Comment.created_at, back_populates="author"
+    "Comment", order_by=Comment.created_at, back_populates="author", passive_deletes=True
 )
 
 Track.author = relationship("User", back_populates="authored_tracks")
 User.authored_tracks = relationship(
-    "Track", order_by=Track.created_at, back_populates="author"
+    "Track", order_by=Track.created_at, back_populates="author", passive_deletes=True
 )
 
 Comment.track = relationship("Track", back_populates="comments")
 Track.comments = relationship(
-    "Comment", order_by=Comment.created_at, back_populates="track"
+    "Comment", order_by=Comment.created_at, back_populates="track", passive_deletes=True
 )
 
 OvertakingEvent.track = relationship("Track", back_populates="overtaking_events")
 Track.overtaking_events = relationship(
-    "OvertakingEvent", order_by=OvertakingEvent.time, back_populates="track"
+    "OvertakingEvent", order_by=OvertakingEvent.time, back_populates="track", passive_deletes=True
 )
 
 


### PR DESCRIPTION
# Summary

This fixes #206. When I delete a track, the event points on the public map are deleted as well.

@gluap @opatut I dont know how to add migrations. Please support. Thanks.

# Solution

[This sounds exaclty like our problem](https://stackoverflow.com/questions/5033547/sqlalchemy-cascade-delete):

>  I cannot get a simple cascade delete to operate correctly -- if a parent element is a deleted, the children persist, with null foreign keys

[That thread also provides a solution](https://stackoverflow.com/a/38770040/605890):

> Setting the passive_deletes=True prevents SqlAlchemy from NULLing out the foreign keys.

This is, what is MR does: It adds `passive_deletes=True` to the relationships.

See:
* https://stackoverflow.com/a/38770040/605890
* https://docs.sqlalchemy.org/en/14/orm/cascades.html