### PR TITLE
Make parseHash function working with negative values

### DIFF
--- a/frontend/src/components/Map/index.tsx
+++ b/frontend/src/components/Map/index.tsx
@@ -31,7 +31,7 @@ export const withBaseMapStyle = connect((state) => ({
 
 function parseHash(v: string): Viewport | null {
   if (!v) return null;
-  const m = v.match(/^#([0-9\.]+)\/([0-9\.]+)\/([0-9\.]+)$/);
+  const m = v.match(/^#([0-9\.]+)\/([0-9\.\-]+)\/([0-9\.\-]+)$/);
   if (!m) return null;
   return {
     zoom: Number.parseFloat(m[1]),


### PR DESCRIPTION
When moving to a negative latitude or longitude on the maps, the view is zoomed out to the maximum and centred on the 0,0.

This change corrects this behaviour.