### PR TITLE
Add an optionally-displayable "Terms and Conditions" link.

### DIFF
--- a/api/config.dev.py
+++ b/api/config.dev.py
@@ -19,6 +19,7 @@ FRONTEND_DIR = None
 FRONTEND_CONFIG = {
     "imprintUrl": "https://example.com/imprint",
     "privacyPolicyUrl": "https://example.com/privacy",
+    # "termsUrl": "https://example.com/terms", # Link is only shown when set
     "mapHome": {"zoom": 6, "longitude": 10.2, "latitude": 51.3},
     # "banner": {"text": "This is a development installation.", "style": "info"},
 }

--- a/api/config.py.example
+++ b/api/config.py.example
@@ -44,6 +44,7 @@ FRONTEND_DIR = "../frontend/build/"
 FRONTEND_CONFIG = {
     "imprintUrl": "https://example.com/imprint",
     "privacyPolicyUrl": "https://example.com/privacy",
+    # "termsUrl": "https://example.com/user_terms_and_conditions", # Link is only shown when set
     "mapHome": {"zoom": 6, "longitude": 10.2, "latitude": 51.3},
     "banner": {"text": "This is a test installation.", "style": "warning"},
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -219,6 +219,13 @@ const App = connect((state) => ({login: state.login}))(function App({login}) {
                       {t('App.footer.imprint')}
                     </a>
                   </List.Item>
+                  { config?.termsUrl &&
+                      <List.Item>
+                          <a href={config?.termsUrl} target="_blank" rel="noreferrer">
+                               {t('App.footer.terms')}
+                           </a>
+                       </List.Item>
+                   }
                   <List.Item>
                     <a
                       href={`https://github.com/openbikesensor/portal${

--- a/frontend/src/config.ts
+++ b/frontend/src/config.ts
@@ -17,6 +17,7 @@ export interface Config {
   obsMapSource?: MapSource;
   imprintUrl?: string;
   privacyPolicyUrl?: string;
+  termsUrl?: string;
   banner?: {
     text: string;
     style?: "warning" | "info";

--- a/frontend/src/translations/de.yaml
+++ b/frontend/src/translations/de.yaml
@@ -29,6 +29,7 @@ App:
 
     thisInstallation: Diese Installation
     privacyPolicy: Datenschutz
+    terms: Nutzungsbedingungen
     imprint: Impressum
     version: Version v{{apiVersion}}
     versionLoading: Version lädt...

--- a/frontend/src/translations/en.yaml
+++ b/frontend/src/translations/en.yaml
@@ -34,6 +34,7 @@ App:
 
     thisInstallation: This installation
     privacyPolicy: Privacy policy
+    terms: Terms and Conditions
     imprint: Imprint
     version: Version v{{apiVersion}}
     versionLoading: Fetching version...

--- a/frontend/src/translations/fr.yaml
+++ b/frontend/src/translations/fr.yaml
@@ -34,6 +34,7 @@ App:
 
     thisInstallation: Cette installation
     privacyPolicy: Politique de confidentialité
+    terms: Modalités d'utilisation
     imprint: Impression
     version: Version v{{apiVersion}}
     versionLoading: Téléchargement de la version...
@@ -232,7 +233,7 @@ SettingsPage:
       Ici vous trouvez votre clé API, pour l'utilisation dans le OpenBikeSensor.
       Vous pouvez la copier et coller dans l'interface de configuration de votre
       capteur pour permettre le le téléchargement direct depuis le dispositif.
-      
+
       Veuillez protéger votre clé API soigneusement car elle permet un contrôle
       total sur votre compte.
     urlDescription: |
@@ -330,15 +331,15 @@ TrackEditor:
       travaillez ou séjournez fréquemment. Votre appareil d'enregistrement peut disposer
       de paramètres de confidentialité utiles pour ne pas enregistrer les données de
       géolocalisation à proximité de ces lieux.
-      
+
       À l'avenir, ce site vous permettra d'expurger les données sensibles relatives
       à la vie privée dans les enregistrements, à la fois manuellement et automatiquement.
       D'ici là, vous devrez compter sur les fonctionnalités de votre appareil d'enregistrement,
       ou expurger manuellement vos fichiers avant de les télécharger.
-      
+
       Après avoir coché cette case, vos données deviennent essentiellement publiques.
       Vous comprenez que nous ne pouvons pas contrôler qui télécharge potentiellement
       ces données et et en conserve une copie, même si vous les supprimez de votre compte
       ou les rendez anonymes plus tard.
-      
+
       **Utilisation à vos risques et périls.**


### PR DESCRIPTION
Now that more initiatives use terms and conditions I think it makes sense to allow linking to them.

My Idea how we could serve the "default" terms in the future would be to set a default value pointing to built-in conditions overridable by using a manual setting.