### PR TITLE
fix: add scrollbar to mapSidebar on overflow

### DIFF
--- a/frontend/src/pages/MapPage/styles.module.less
+++ b/frontend/src/pages/MapPage/styles.module.less
@@ -17,6 +17,7 @@
   background: white;
   border-right: 1px solid @borderColor;
   padding: 1rem;
+  overflow-y: auto;
 }
 
 .map {


### PR DESCRIPTION
Currently no scrollbar is shown if the mapSidebar overflows => some of the content may not be visible.
With this fix a scrollbar is shown if necessary.