### PR TITLE
fix: remove compass from map

### DIFF
--- a/frontend/src/components/Map/index.tsx
+++ b/frontend/src/components/Map/index.tsx
@@ -160,7 +160,7 @@ function Map({
       attributionControl={false}
     >
       <AttributionControl style={{ top: 0, right: 0 }} />
-      <NavigationControl style={{ left: 16, top: hasToolbar ? 64 : 16 }} />
+      <NavigationControl showCompass={false} style={{ left: 16, top: hasToolbar ? 64 : 16 }} />
       <ScaleControl
         maxWidth={200}
         unit="metric"


### PR DESCRIPTION
As the map can not be rotated, the Button "Reset North" does not make much sense. => This pr removes it.

Before pr:
![portal](https://github.com/openbikesensor/portal/assets/65826058/6d6b33e2-cee5-4b07-bce5-e0fe742011c1)

After pr:
![Screenshot 2023-06-11 165951](https://github.com/openbikesensor/portal/assets/65826058/95d9164d-d3a6-4aff-b9fb-b7f610675281)
