### PR TITLE
api/tracks: change default order_by of tracks to desc

### DIFF
--- a/api/obs/api/routes/tracks.py
+++ b/api/obs/api/routes/tracks.py
@@ -41,7 +41,7 @@ async def _return_tracks(req, extend_query, limit, offset, order_by=None):
         extend_query(select(Track).options(joinedload(Track.author)))
         .limit(limit)
         .offset(offset)
-        .order_by(order_by if order_by is not None else Track.created_at)
+        .order_by(order_by if order_by is not None else Track.created_at.desc())
     )
 
     tracks = (await req.ctx.db.execute(query)).scalars()


### PR DESCRIPTION
Correctly show newest track on the start page and also order the tracks in the public track view from newest to oldest