### PR TITLE
Toggle snapping

### DIFF
--- a/api/obs/api/process/__init__.py
+++ b/api/obs/api/process/__init__.py
@@ -362,7 +362,7 @@ def get_road_usage_segments(df):
 async def import_road_usages(session, track, df):
     usages = {}
     for way_id, rows in get_road_usage_segments(df):
-        direction_reversed = numpy.mean(df["direction_reversed"]) > 0.5
+        direction_reversed = numpy.mean(list(r["direction_reversed"] for r in rows)) > 0.5
         start_time = rows[0]["datetime"]
         end_time = rows[-1]["datetime"]
         time = start_time + (end_time - start_time) / 2

--- a/api/obs/api/routes/exports.py
+++ b/api/obs/api/routes/exports.py
@@ -72,9 +72,6 @@ async def export_events(req):
     async with use_request_semaphore(req, "export_semaphore", timeout=30):
         bbox = req.ctx.get_single_arg("bbox", default="-180,-90,180,90")
         snap = str_to_bool(req.ctx.get_single_arg("snap", default="false"))
-        log.info(req.ctx)
-        log.info(snap)
-
 
         assert re.match(r"(-?\d+\.?\d+,?){4}", bbox)
         bbox = list(map(float, bbox.split(",")))

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -14,7 +14,7 @@ memoization>=0.3.2
 motor~=3.1.1
 msgpack~=1.0.5
 networkx>=3.2.1
-numpy==1.24.2
+numpy==1.26.3
 oic~=1.5.0
 osmium~=3.6.0
 pandas>=2.2.1

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -23,7 +23,7 @@ pyproj~=3.6.1
 pyshp~=2.3.1
 python-slugify~=6.1.2
 pytz==2023.2
-pyyaml~=5.3.1
+pyyaml>=5.3.1
 requests>=2.25.1
 sanic-session~=0.8.0
 sanic==22.6.2

--- a/api/tools/prepare_sql_tiles.py
+++ b/api/tools/prepare_sql_tiles.py
@@ -29,11 +29,12 @@ EXTRA_ARGS = [
     ("user_id", "integer", "NULL"),
     ("min_time", "timestamp", "NULL"),
     ("max_time", "timestamp", "NULL"),
+    ("snap", "boolean", "false"),
 ]
 
 
 class CustomMvtGenerator(MvtGenerator):
-    def generate_sqltomvt_func(self, fname, extra_args: List[Tuple[str, str]]) -> str:
+    def generate_sqltomvt_func(self, fname, extra_args: List[Tuple[str, str, str]]) -> str:
         """
         Creates a SQL function that returns a single bytea value or null. This
         method is overridden to allow for custom arguments in the created function

--- a/api/tools/reimport_tracks.py
+++ b/api/tools/reimport_tracks.py
@@ -22,7 +22,7 @@ async def reimport_tracks():
         app.config.POSTGRES_MAX_OVERFLOW,
     ):
         async with make_session() as session:
-            await session.execute(text("UPDATE track SET processing_status = 'queued';"))
+            await session.execute(text("UPDATE track SET processing_status = 'queued', processing_queued_at = '2030-01-01 10:10:10.000000';"))
             await session.commit()
 
 

--- a/frontend/src/pages/ExportPage/index.tsx
+++ b/frontend/src/pages/ExportPage/index.tsx
@@ -1,7 +1,7 @@
 import React, {useState, useCallback, useMemo} from 'react'
 import {Source, Layer} from 'react-map-gl'
 import _ from 'lodash'
-import {Button, Form, Dropdown, Header, Message, Icon} from 'semantic-ui-react'
+import {Button, Form, Dropdown, Header, Message, Icon, Checkbox} from 'semantic-ui-react'
 import {useTranslation, Trans as Translate} from 'react-i18next'
 import Markdown from 'react-markdown'
 
@@ -96,6 +96,8 @@ const FORMATS = ['geojson', 'shapefile']
 
 export default function ExportPage() {
   const [mode, setMode] = useState('events')
+  const [snap, setSnap] = useState('snap')
+
   const [bbox, setBbox] = useState('8.294678,49.651182,9.059601,50.108249')
   const [fmt, setFmt] = useState('geojson')
   const config = useConfig()
@@ -127,6 +129,16 @@ export default function ExportPage() {
             onChange={(_e, {value}) => setMode(value)}
           />
         </Form.Field>
+        <Form.Field>
+        <Checkbox
+          label={t('ExportPage.snapping')}
+          name="snap"
+          value="true"
+          onChange={(_e, {value}) => setSnap(!snap)}
+
+        />
+        </Form.Field>
+
 
         <Form.Field>
           <label>{t('ExportPage.format.label')}</label>
@@ -149,7 +161,7 @@ export default function ExportPage() {
         <Button
           primary
           as="a"
-          href={`${config?.apiUrl}/export/${mode}?bbox=${bbox}&fmt=${fmt}`}
+          href={`${config?.apiUrl}/export/${mode}?bbox=${bbox}&fmt=${fmt}&snap=${snap}`}
           target="_blank"
           rel="noreferrer noopener"
         >

--- a/frontend/src/pages/MapPage/LayerSidebar.tsx
+++ b/frontend/src/pages/MapPage/LayerSidebar.tsx
@@ -79,7 +79,7 @@ function LayerSidebar({
     obsEvents: {show: showEvents},
     obsRegions: {show: showRegions},
     obsTracks: {show: showTracks},
-    filters: {currentUser: filtersCurrentUser, dateMode, startDate, endDate, thresholdAfter},
+    filters: {currentUser: filtersCurrentUser, dateMode, startDate, endDate, thresholdAfter, snapEvents},
   } = mapConfig
 
   const openStreetMapCopyright = (
@@ -257,6 +257,12 @@ function LayerSidebar({
         </List.Item>
         {showEvents && (
           <>
+             <List.Item>
+              <Checkbox
+                checked={snapEvents}
+                onChange={() => setMapConfigFlag('filters.snapEvents', !snapEvents)}
+                label={t('MapPage.sidebar.obsEvents.snap')}/>
+            </List.Item>
             <List.Item>
               <List.Header>{_.upperFirst(t('general.zone.urban'))}</List.Header>
               <DiscreteColorMapLegend map={COLORMAP_URBAN} />
@@ -265,8 +271,12 @@ function LayerSidebar({
               <List.Header>{_.upperFirst(t('general.zone.rural'))}</List.Header>
               <DiscreteColorMapLegend map={COLORMAP_RURAL} />
             </List.Item>
+
           </>
         )}
+
+
+
         <Divider />
 
         {filtersCurrentUser && login && (

--- a/frontend/src/pages/MapPage/index.tsx
+++ b/frontend/src/pages/MapPage/index.tsx
@@ -276,10 +276,14 @@ function MapPage({login}) {
 
   const tiles = obsMapSource?.tiles?.map((tileUrl: string) => {
     const query = new URLSearchParams()
+      if (mapConfig.filters.snapEvents) {
+        query.append('snap', true)
+      }
     if (login) {
       if (mapConfig.filters.currentUser) {
         query.append('user', login.id)
       }
+
 
       if (mapConfig.filters.dateMode === 'range') {
         if (mapConfig.filters.startDate) {

--- a/frontend/src/reducers/mapConfig.ts
+++ b/frontend/src/reducers/mapConfig.ts
@@ -43,6 +43,7 @@ export type MapConfig = {
     startDate?: null | string
     endDate?: null | string
     thresholdAfter?: null | boolean
+    snap?: false | boolean
   }
 }
 
@@ -71,6 +72,7 @@ export const initialState: MapConfig = {
     startDate: null,
     endDate: null,
     thresholdAfter: true,
+    snap: false
   },
 }
 

--- a/frontend/src/translations/de.yaml
+++ b/frontend/src/translations/de.yaml
@@ -91,6 +91,7 @@ ExportPage:
     rechenaufwändig ist, nutze ihn daher nur so häufig wie nötig und nur in
     begrenzten geografischen Bereichen, je nach Bedarf.
   export: Exportieren
+  snapping: Events auf die zugeordneten Straßensegmente "snappen"
   mode:
     label: Modus
     placeholder: Modus wählen
@@ -173,6 +174,7 @@ MapPage:
 
     obsEvents:
       title: Überholvorgänge
+      snap: Events auf Straßen "snappen"
 
     obsTracks:
       title: Meine eigenen Fahrten

--- a/frontend/src/translations/de.yaml
+++ b/frontend/src/translations/de.yaml
@@ -163,12 +163,12 @@ MapPage:
         usage_count: Anzahl Befahrungen
         zone: Überholabstands-Zone
         combined_score: Kombinierte Auswertung
-        overtaking_legality: Anteil illegal
+        overtaking_legality: Anteil unter 150 cm
         overtaking_frequency: Überholvorgänge pro km
       combinedScore:
         label: Wertungsskala
         description: >
-          Die Wertung kombiniert den Anteil illegaler Überholungen
+          Die Wertung kombiniert den Anteil Überholungen unter 150 cm
           mit der Anzahl der Überholvorgänge pro gefahrener Distanz.
           Weniger Verkehr kann schlechte Abstände aufwiegen.
 

--- a/frontend/src/translations/en.yaml
+++ b/frontend/src/translations/en.yaml
@@ -92,6 +92,7 @@ ExportPage:
     possible and do not exceed unreasonable poll frequencies.
 
   export: Export
+  snapping: Snap events to OpenStreetMap
   mode:
     label: Mode
     placeholder: Select mode
@@ -175,6 +176,8 @@ MapPage:
 
     obsEvents:
       title: Event points
+      snap: Snap events to road segments
+
 
     obsTracks:
       title: My own tracks

--- a/frontend/src/translations/en.yaml
+++ b/frontend/src/translations/en.yaml
@@ -165,12 +165,12 @@ MapPage:
         segment_length: Segment length (m)
         zone: Overtaking distance zone
         combined_score: Combined score
-        overtaking_legality: Percent illegal
+        overtaking_legality: Percent below 150cm
         overtaking_frequency: Events per kilometer
       combinedScore:
         label: Score
         description: >
-          The score combines the percentage of illegal overtakings with the
+          The score combines the percentage of overtakings < 150cm with the
           number of overtakings per distance of usage (overtaking frequency).
           Less traffic can be as helpful as more overtaking distance.
 

--- a/frontend/src/translations/fr.yaml
+++ b/frontend/src/translations/fr.yaml
@@ -93,6 +93,7 @@ ExportPage:
     sélectionnez la zone de délimitation la plus petit possible et
     n'effectuez pas d'export à répétition.
   export: Exporter
+  snap: Snap evénements sur les rues
   mode:
     label: Mode
     placeholder: Sélectionner un mode
@@ -176,6 +177,7 @@ MapPage:
 
     obsEvents:
       title: Points d'événement
+      snap: Snap points d'événement sur rues
 
     obsTracks:
       title: Mes propre traces

--- a/frontend/src/translations/fr.yaml
+++ b/frontend/src/translations/fr.yaml
@@ -164,13 +164,13 @@ MapPage:
         usage_count: Nombre de passages
         zone: Overtaking distance zone
         combined_score: Score combinée
-        overtaking_legality: Pourcent illégal
+        overtaking_legality: Pourcent sous 150cm
         overtaking_frequency: Dépassements par km
       combinedScore:
         label: Score
         description: >
           Le score combine le pourcentage de dépassements
-          rapprochés et le nombre de dépassements par distance
+          sous 150cm et le nombre de dépassements par distance
           d'utilisation de la route (fréquence de dépassement).
           Un trafic réduit peut être aussi utile qu'une plus grande
           distance de dépassement.

--- a/tile-generator/layers/obs_events/layer.sql
+++ b/tile-generator/layers/obs_events/layer.sql
@@ -1,11 +1,12 @@
 DROP FUNCTION IF EXISTS layer_obs_events(bbox geometry, zoom_level int, user_id integer, min_time timestamp, max_time timestamp);
+DROP FUNCTION IF EXISTS layer_obs_events(bbox geometry, zoom_level int, user_id integer, min_time timestamp, max_time timestamp, snap boolean);
 
-CREATE OR REPLACE FUNCTION layer_obs_events(bbox geometry, zoom_level int, user_id integer, min_time timestamp, max_time timestamp)
+CREATE OR REPLACE FUNCTION layer_obs_events(bbox geometry, zoom_level int, user_id integer, min_time timestamp, max_time timestamp, snap boolean)
 RETURNS TABLE(event_id bigint, geometry geometry, distance_overtaker float, distance_stationary float, direction int, course float, speed float, time_stamp timestamp, zone zone_type, way_id bigint) AS $$
 
     SELECT
       overtaking_event.id::bigint as event_id,
-      overtaking_event.geometry as geometry,
+      CASE WHEN snap THEN ST_ClosestPoint(road.geometry,overtaking_event.geometry) else overtaking_event.geometry END as geometry,
       distance_overtaker,
       distance_stationary,
       (case when direction_reversed then -1 else 1 end)::int as direction,

--- a/tile-generator/layers/obs_events/obs_events.yaml
+++ b/tile-generator/layers/obs_events/obs_events.yaml
@@ -32,7 +32,7 @@ layer:
         SELECT
           event_id, geometry, distance_overtaker, distance_stationary, direction, course, speed, zone, way_id
         FROM
-          layer_obs_events(!bbox!, z(!scale_denominator!), user_id, min_time, max_time)
+          layer_obs_events(!bbox!, z(!scale_denominator!), user_id, min_time, max_time, snap)
       ) AS t
 
 schema:


### PR DESCRIPTION
@opatut this enables event snapping for both the map and the export function. No database schema update required, only ``tools/prepare_sql_tiles.py``